### PR TITLE
WaveParts: Added missing translation & Updates some obsolete/bad transla...

### DIFF
--- a/WaveParts/res/values-ro/strings.xml
+++ b/WaveParts/res/values-ro/strings.xml
@@ -1,52 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="app_name">Setări Wave</string>
-  <string name="category_screen_title">Ecran</string>
-  <string name="color_tuning_title_head">Reglaj Culori</string>
-  <string name="color_tuning_summary_head">Calibraţi culorile ecranului</string>
-  <string name="color_red_title">Roşu</string>
-  <string name="color_green_title">Verde</string>
-  <string name="color_blue_title">Albastru</string>
-  <string name="color_red_gamma_title">Gamma Roşu</string>
-  <string name="color_green_gamma_title">Gamma Verde</string>
-  <string name="color_blue_gamma_title">Gamma Albastru</string>
-  <string name="mdnie_title_head">Mod mDNIe</string>
-  <string name="mdnie_summary_head">Reglaj post-procesare mDNIe</string>
-  <string name="category_radio_title">Radio</string>
-  <string name="hspa_title_head">HSPA</string>
-  <string name="hspa_summary_head">Activaţi HSDPA/HSUPA</string>
-  <string name="category_tvout_title">TV Out</string>
-  <string name="tvout_enable_head">TV Out</string>
-  <string name="tvout_enable_summary_nocable">Cablul TV Out nu este conectat</string>
-  <string name="tvout_enable_summary">Cablul TV Out este conectat, selectaţi pentru activare</string>
-  <string name="tvout_enable_summary_on">TV Out activat</string>
-  <string name="tvout_system_head">Standard TV</string>
-  <string name="tvout_system_summary">Setaţi standardul TV pentru TV Out</string>
-  <string name="category_volume_boost_title">Control Volum</string>
-  <string name="volume_boost_title_head">Control Volum Apel Intrare</string>
-  <string name="volume_boost_summary_head">Setări volum amplificare apel intrare </string>
-  <string name="boost_rcv_title">Volumul Receptorului</string>
-  <string name="boost_bt_title">Volum Bluetooth</string>
-  <string name="boost_spk_title">Volum Difuzor</string>
-  <string name="boost_hp_title">Volumul Setului cu cască</string>
-  <string name="mic_rcv_title">Microfon Receptor</string>
-  <string name="mic_spk_title">Microfon Difuzor</string>
-  <string name="mic_hp_title">Set cu cască Microfon</string>
-  <string name="mic_hp_no_mic_title">Set cu cască (fără microfon) Microfon</string>
-  <string name="cardock_audio_title_head">Car Dock</string>
-  <string name="deskdock_audio_title_head">Desk Dock</string>
-  <string name="category_dock_audio_title">Dock Audio</string>
-  <string name="cardock_audio_summary_on">Audio pentru car dock activat</string>
-  <string name="cardock_audio_summary_off">Audio pentru car dock dezactivat</string>
-  <string name="deskdock_audio_summary_on">Audio pentru desk dock activat</string>
-  <string name="deskdock_audio_summary_off">Audio pentru desk dock dezactivat</string>
-  <string name="category_vibration_title">Vibrare</string>
-  <string name="vibration_title_head">Vibrare</string>
-  <string name="vibration_summary_head">Control intensitate vibraţii</string>
-  <string name="vibration_title">Intesitate vibraţii</string>
-  <string name="vibration_test_title">Testaţi</string>
-  <string name="button_reset_title">Resetați</string>
-  <string name="generic_warning_title">Avertisment</string>
-  <string name="imei_not_sane_message">A fost detectată o problemă la dispozitivul dvs. IMEI-ul dispozitivului nu este valid. Un IMEI nevalid poate provoca probleme de reţea inclusiv incapacitatea de a apela nr. de urgenţă.</string>
-  <string name="imei_not_sane_ok">OK</string>
+  <string name="app_name">Setări Avansate</string>
+	
+	<string name="category_screen_title">Ecran</string>
+	<string name="color_tuning_title_head">Reglaj Culori</string>
+	<string name="color_tuning_summary_head">Calibrează culorile ecranului</string>
+	<string name="color_red_title">Roşu</string>
+	<string name="color_green_title">Verde</string>
+	<string name="color_blue_title">Albastru</string>
+	<string name="color_red_gamma_title">Gamma Roşu</string>
+	<string name="color_green_gamma_title">Gamma Verde</string>
+	<string name="color_blue_gamma_title">Gamma Albastru</string>
+	
+	<string name="mdnie_title_head">Mod mDNIe</string>
+	<string name="mdnie_summary_head">Reglaj post-procesare mDNIe</string>
+	
+	<string name="category_radio_title">Radio</string>
+	<string name="hspa_title_head">HSPA</string>
+	<string name="hspa_summary_head">Activează HSDPA/HSUPA</string>
+	
+	<string name="category_tvout_title">TV Out</string>
+	<string name="tvout_enable_head">TV Out</string>
+	<string name="tvout_enable_summary_nocable">Cablul TV Out nu este conectat</string>
+	<string name="tvout_enable_summary">Cablul TV Out este conectat, selectaţi pentru activare</string>
+	<string name="tvout_enable_summary_on">TV Out activat</string>
+	<string name="tvout_system_head">Standard TV</string>
+	<string name="tvout_system_summary">Setează standardul TV pentru TV Out</string>
+	
+	<string name="category_volume_boost_title">Control Volum</string>
+	<string name="volume_boost_title_head">Control Volum Apel Intrare</string>
+	<string name="volume_boost_summary_head">Setări volum amplificare apel intrare </string>
+	<string name="boost_rcv_title">Volum Receptor</string>
+	<string name="boost_bt_title">Volum Bluetooth</string>
+	<string name="boost_spk_title">Volum Difuzor</string>
+	<string name="boost_hp_title">Volum Căști</string>
+	<string name="mic_rcv_title">Microfon Receptor</string>
+	<string name="mic_spk_title">Microfon Difuzor</string>
+	<string name="mic_hp_title">Căști cu Microfon</string>
+	<string name="mic_hp_no_mic_title">Căști (fără microfon)</string>
+	<string name="cardock_audio_title_head">Car Dock</string>
+	<string name="deskdock_audio_title_head">Desktop Audio</string>
+	
+	<string name="category_dock_audio_title">Conector audio</string>
+	<string name="cardock_audio_summary_on">Audio pentru car dock activat</string>
+	<string name="cardock_audio_summary_off">Audio pentru car dock dezactivat</string>
+	<string name="deskdock_audio_summary_on">Audio pentru Desktop activat</string>
+	<string name="deskdock_audio_summary_off">Audio pentru Desktop dezactivat</string>
+	
+	<string name="category_vibration_title">Vibraţii</string>
+	<string name="vibration_title_head">Vibraţii</string>
+	<string name="vibration_summary_head">Control intensitate vibraţii</string>
+	<string name="vibration_title">Intesitate vibraţii</string>
+	<string name="vibration_test_title">Testează</string>
+	<string name="button_reset_title">Resetează</string>
+  <string name="generic_warning_title">Atenţie</string>
+  
+  <string name="imei_not_sane_title">Atenţie!</string>
+	<string name="imei_not_sane_message">A fost detectată o problemă în cadrul dispozitivului. IMEI-ul dispozitivului nu este valid. Un IMEI invalid poate provoca probleme de reţea inclusiv incapacitatea de a apela nr. de urgenţă.</string>
+	<string name="imei_not_sane_ok">OK</string>
 </resources>


### PR DESCRIPTION
Updated translations:
    - app_name
    - color_tuning_summary_head
    - hspa_summary_head
    - tvout_system_summary
    - category_volume_boost_title
    - mdnie_summary_head
    - boost_hp_title
    - mic_hp_title
    - mic_hp_no_mic_title
    - deskdock_audio_title_head
    - category_dock_audio_title
    - deskdock_audio_summary_on
    - deskdock_audio_summary_off
    - category_vibration_title
    - vibration_title_head
    - vibration_test_title
    - button_reset_title
    - generic_warning_title
    - imei_not_sane_message

Added strings(translated):
    - imei_not_sane_title
