### PR TITLE
WaveParts: Added missing translation & Updates some obsolete/bad translations

### DIFF
--- a/WaveParts/res/values-it/strings.xml
+++ b/WaveParts/res/values-it/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Impostazioni Wave</string>
+    <string name="app_name">Impostazioni Avanzate</string>
+
     <string name="category_screen_title">Display</string>
     <string name="color_tuning_title_head">Calibrazione colori</string>
     <string name="color_tuning_summary_head">Calibra colori display</string>
@@ -12,18 +13,21 @@
     <string name="color_blue_gamma_title">Gamma Blu</string>
     <string name="mdnie_title_head">Modalità mDNIe</string>
     <string name="mdnie_summary_head">Imposta grado di post-processamento del display</string>
-    <string name="category_radio_title">Gestione della rete</string>
+
+    <string name="category_radio_title">Radio</string>
     <string name="hspa_title_head">HSPA</string>
     <string name="hspa_summary_head">Abilita HSDPA/HSUPA</string>
+
     <string name="category_tvout_title">Uscita TV</string>
     <string name="tvout_enable_head">Uscita TV</string>
     <string name="tvout_enable_summary_nocable">Cavo per uscita TV non connesso</string>
     <string name="tvout_enable_summary">Cavo per uscita TV connesso, clicca per attivare</string>
     <string name="tvout_enable_summary_on">Uscita TV attivata</string>
     <string name="tvout_system_head">Sistema TV</string>
-    <string name="tvout_system_summary">Imposta il sistema TV per l\' uscita TV</string>
-    <string name="category_volume_boost_title">Regolazione volume</string>
-    <string name="volume_boost_title_head">Regolazione volume chiamate</string>
+    <string name="tvout_system_summary">Imposta il sistema TV per l'uscita TV</string>
+
+    <string name="category_volume_boost_title">Controlli del Volume</string>
+    <string name="volume_boost_title_head">Regolazioni volume chiamate</string>
     <string name="volume_boost_summary_head">Potenzia il volume delle chiamate</string>
     <string name="boost_rcv_title">Volume auricolare</string>
     <string name="boost_bt_title">Volume Bluetooth</string>
@@ -33,6 +37,7 @@
     <string name="mic_spk_title">Microfono vivavoce</string>
     <string name="mic_hp_title">Microfono cuffie</string>
     <string name="mic_hp_no_mic_title">Microfono cuffie (senza mic.)</string>
+
     <string name="category_dock_audio_title">Dock Audio</string>
     <string name="cardock_audio_title_head">Dock da auto</string>
     <string name="cardock_audio_summary_on">Audio dock da auto attivato</string>
@@ -40,14 +45,20 @@
     <string name="deskdock_audio_title_head">Dock da tavolo</string>
     <string name="deskdock_audio_summary_on">Audio dock da tavolo attivato</string>
     <string name="deskdock_audio_summary_off">Audio dock da tavolo disattivato</string>
+    
     <string name="category_vibration_title">Vibrazione</string>
     <string name="vibration_title_head">Vibrazione</string>
     <string name="vibration_summary_head">Controllo intensità vibrazione</string>
     <string name="vibration_title">Intensità vibrazione</string>
     <string name="vibration_test_title">Prova</string>
+    
     <string name="button_reset_title">Ripristina</string>
+    
+    <!-- Usato per il titolo dell'attività. Di solito non è visibile, se non sullo schermo degli multi-task -->
     <string name="generic_warning_title">Attenzione</string>
+    
+    <!-- IMEI Non Valido -->
     <string name="imei_not_sane_title">Attenzione!</string>
-    <string name="imei_not_sane_message">È stato rilevato un problema con il dispositivo. Il numero IMEI del dispositivo non è valido. Un numero IMEI non valido potrebbe causare problemi di rete tra cui l\'impossibilità di chiamare numeri di emergenza.</string>
-    <string name="imei_not_sane_ok">Ok</string>
+    <string name="imei_not_sane_message">È stato rilevato un problema con il dispositivo. Il numero IMEI del dispositivo non è valido. Un numero IMEI non valido potrebbe causare problemi di rete tra cui l'impossibilità di chiamare numeri di emergenza.</string>
+    <string name="imei_not_sane_ok">OK</string>
 </resources>


### PR DESCRIPTION
Updated translations:
- app_name
- category_radio_title
- tvout_system_summary
- category_volume_boost_title
- volume_boost_title_head
- imei_not_sane_message
- imei_not_sane_ok

Added strings(translated):
- None
